### PR TITLE
Improve SignOutReviewWindow

### DIFF
--- a/DB/MdbInterface.java
+++ b/DB/MdbInterface.java
@@ -83,18 +83,23 @@ public class MdbInterface {
 		ActiveStudents.remove(sod.getEmplId());
 		String time_out = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss").format(new Date());
 
-		BasicDBList topicList = new BasicDBList();
+		Document time_doc = new Document()
+				.append("TIMEOUT", time_out)
+				.append("TUTOR", sod.getTutor().toString());
+
+		// If not in 135, then Topics discussed will be be null. Do not insert empty list into DB.
 		if (sod.getTopics() != null){
+			BasicDBList topicList = new BasicDBList();
 			for (Topics135 topic : sod.getTopics())
 				topicList.add(topic.toString());
+			time_doc.append("TOPICSDISCUSSED", topicList);
 		}
 
-		Document time_doc = new Document()
-							.append("TIMEOUT", time_out)
-							.append("TOPICSDISCUSSED", topicList)
-							.append("LEVELOFLEARNING", sod.getLevelOfLearning())
-							.append("TUTOR", sod.getTutor().toString());
-		
+		// If not in 135, then Level of Learning will be null. Do not insert -1 value in to DB.
+		if (sod.getLevelOfLearning() != -1) {
+			time_doc.append("LEVELOFLEARNING", sod.getLevelOfLearning());
+		}
+
 		Document queryEMPLID = new Document("EMPLID", sod.getEmplId());
 		Document update = new Document("$set", new Document( "LOG."+time_in , time_doc) );
 		Attendance.updateOne(queryEMPLID, update);

--- a/Information/Topics135.java
+++ b/Information/Topics135.java
@@ -1,18 +1,18 @@
 package Information;
 
 public enum Topics135 {
-    CONTROL_FLOW_AND_LOOPS("Flow of Control / Loops"),
+    CONTROL_FLOW_AND_LOOPS("Control Flow / Loops"),
     FUNCTIONS("Functions"),
     ARRAYS("Arrays"),
     RECURSION("Recursion"),
+    CHARACTERS_AND_ASCII_CODE("Characters / ASCII Code"),
     STRINGS("Strings"),
     STREAMS_AND_FILE_IO("Streams / File IO"),
-    CHARACTERS_AND_ASCII_CODE("Characters / ASCII CODE"),
-    CLASSES_STRUCTS_OOP("Classes / Structs / OOP"),
     PARAMETERS_REFERENCE_AND_VALUE("Call by Reference & Value"),
     OPERATOR_OVERLOADING("Operator Overloading"),
-    POINTERS_AND_DYNAMIC_ARRAYS("Pointers / Dynamic Arrays"),
+    CLASSES_STRUCTS_OOP("Classes / Structs / OOP"),
     SEPARATE_COMPILATION_LINUX("Separate Compilation / Linux"),
+    POINTERS_AND_DYNAMIC_ARRAYS("Pointers / Dynamic Arrays"),
     LINKED_DATA_STRUCTURES("Linked Data Structures"),
     OTHER("Other");
 

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: GUI.Main
+


### PR DESCRIPTION
Make level of learning hidden, alongside topic list, if 135 is not checked. Made visible when 135 is checked.
Make labels for level of learning and tutor dropdowns.
Enforce that if 135 is checked, level of learning cannot be null, and at least 1 selection must be made for topics. If 135 is not checked, only tutor must be selected.
Since level of learning can be null, it would not be added to the DB. Added identical functionality if topics is null.